### PR TITLE
[Chore] Update  .npmignore to ignore .github and docs folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,10 @@
 /assets/
 /dev/
-/docs/
+/docs/*
+/docs/*/
+/docs/build/*
+/docs/build/*/
+!docs/build/data.json
 /tests/*
 /tests/*/
 !/tests/helpers/
@@ -8,11 +12,14 @@
 /.*
 *.log
 /yarn.lock
-!docs/build/data.json
 
 # the GitHub Action CI configuration is used by
 # lib/utilities/platform-checker.js to determine what versions of Node are
 # under test by the current version of ember-cli being used, this means we
 # **must** publish this file (but it would be ignored by the `/.*` line just
 # above)
+/.github/*
+/.github/*/
+/.github/workflows/*
+/.github/workflows/*/
 !/.github/workflows/ci.yml


### PR DESCRIPTION
Currently, running `npm pack --dry-run --json | grep "github\|docs"` returns long list with lots of files in `/docs` folder and everything under `.github`.

Tarball Details:
```
npm notice name:          ember-cli                               
npm notice version:       4.0.0-beta.2                            
npm notice filename:      ember-cli-4.0.0-beta.2.tgz              
npm notice package size:  531.9 kB                                
npm notice unpacked size: 2.8 MB
```

After the change, running `npm pack --dry-run --json | grep "github\|docs"` returns:
```
"path": "docs/build/data.json",
"path": ".github/workflows/ci.yml",
"path": "blueprints/addon/files/.github/workflows/ci.yml",
"path": "blueprints/app/files/.github/workflows/ci.yml",
```

With Tarball Details:
```
npm notice name:          ember-cli                               
npm notice version:       4.0.0-beta.2                            
npm notice filename:      ember-cli-4.0.0-beta.2.tgz              
npm notice package size:  259.4 kB                                
npm notice unpacked size: 1.2 MB
```

Problem is that `!docs/build/data.json` "kill" the `/docs/` rule and we need to explicitly ignore files within that dir.